### PR TITLE
add 'no_metadata' parameter to get_hystreet_station_data()

### DIFF
--- a/R/get_hystreet_station_data.R
+++ b/R/get_hystreet_station_data.R
@@ -6,12 +6,14 @@
 #' * from: datetime of earliest measurement (default: today 00:00:00:): e.g. "2018-10-01 12:00:00" or "2018-10-01"
 #' * to : datetime of latest measurement (default: today 23:59:59): e.g. "2018-01-12 12:00:00" or "2018-12-01"
 #' * resolution: Resolution for the measurement grouping (default: hour): "day", "hour", "month", "week"
+#' @param no_metadata [logical] (**optional**): If set to \code{TRUE}, the result contains no meta data but only a clean data frame 
+#' with the measurements of the requested station. Defaults to \code{FALSE}.
 #' @param API_token [character] (**optional**): API key to get access to Hystreet API
 #' 
 #' @return [data.frame] with parsed data from hystreet API
 #'
 #' @section Function version:
-#' 0.0.2
+#' 0.0.3
 #' @author Johannes Friedrich
 #' 
 #' @examples 
@@ -30,6 +32,7 @@
 get_hystreet_station_data <- function(
   hystreetId = NULL, 
   query = NULL,
+  no_metadata = FALSE,
   API_token = NULL){
   
   ##=======================================##
@@ -42,6 +45,9 @@ get_hystreet_station_data <- function(
   if (!is.null(query) && class(query) != "list")
     stop("[get_hystreet_station_data()] Argument 'query' has to be a list", call. = FALSE)
   
+  if(!is.logical(no_metadata)) 
+    stop("The 'no_metadata' parameter has to be logical (TRUE or FALSE).", call. = FALSE)
+  
   # Ids_loop <- lapply(1:length(hystreetId), function(Id){
   
   
@@ -49,11 +55,22 @@ get_hystreet_station_data <- function(
                                   hystreetId = hystreetId, 
                                   query = query)
   
-  res$measurements$timestamp <- .convert_dates(res$measurements$timestamp)
-  res$metadata$earliest_measurement_at <- .convert_dates(res$metadata$earliest_measurement_at)
-  res$metadata$latest_measurement_at <- .convert_dates(res$metadata$latest_measurement_at)
-  
-  return(res)
+  if (no_metadata == TRUE) {
+    
+    res <- res$measurements
+    res$timestamp <- .convert_dates(res$timestamp)
+    
+    return(res)
+    
+  } else {
+    
+    res$measurements$timestamp <- .convert_dates(res$measurements$timestamp)
+    res$metadata$earliest_measurement_at <- .convert_dates(res$metadata$earliest_measurement_at)
+    res$metadata$latest_measurement_at <- .convert_dates(res$metadata$latest_measurement_at)
+    
+    return(res)
+    
+  }
   
   # })
   # 

--- a/man/get_hystreet_station_data.Rd
+++ b/man/get_hystreet_station_data.Rd
@@ -4,7 +4,12 @@
 \alias{get_hystreet_station_data}
 \title{Get data from a specific location from the Hystreet Project via Hystreet API}
 \usage{
-get_hystreet_station_data(hystreetId = NULL, query = NULL, API_token = NULL)
+get_hystreet_station_data(
+  hystreetId = NULL,
+  query = NULL,
+  no_metadata = FALSE,
+  API_token = NULL
+)
 }
 \arguments{
 \item{hystreetId}{\link{integer} (\strong{required}): ID of the requested station. See \code{\link[=get_hystreet_locations]{get_hystreet_locations()}} for an overview of
@@ -17,6 +22,9 @@ available IDs.}
 \item resolution: Resolution for the measurement grouping (default: hour): "day", "hour", "month", "week"
 }}
 
+\item{no_metadata}{\link{logical} (\strong{optional}): If set to \code{TRUE}, the result contains no meta data but only a clean data frame
+with the measurements of the requested station. Defaults to \code{FALSE}.}
+
 \item{API_token}{\link{character} (\strong{optional}): API key to get access to Hystreet API}
 }
 \value{
@@ -27,7 +35,7 @@ Get data from a specific location from the Hystreet Project via Hystreet API
 }
 \section{Function version}{
 
-0.0.2
+0.0.3
 }
 
 \examples{


### PR DESCRIPTION
Dear Johannes, 

thank you so much for your wonderful package! I have recently been using it at work, amongst others, for production purposes. In this context, I want - using this PR - to suggest a slight improvement: add a `no_metadata` parameter to the `get_hystreet_station_data` function. This way, one can easily obtain a clean data frame instead of a list with all meta data where additional code is needed to extract the measurement data frame. This can make using the function easier, especially when one uses it for production purposes, for in some cases it saves additional lines of code.

Let me know what you think and feel free to edit my proposal. 

Best, Yannik