### PR TITLE
add new hystreet.com url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: hystReet
 Type: Package
 Title: Get Pedestrian Frequency Data from the 'Hystreet' Project
-Date: 2021-XX-XX
-Version: 0.0.3
+Date: 2022-11-23
+Version: 0.0.4
 Authors@R: person("Johannes", "Friedrich", role = c("aut", "cre"), email = "Johannes.Friedrich@posteo.de")
 Maintainer: Johannes Friedrich <Johannes.Friedrich@posteo.de>
 Description: An R API wrapper for the 'Hystreet' project <https://hystreet.com>. 'Hystreet' provides pedestrian counts in different cities in Germany.

--- a/R/create_hystreet_request.R
+++ b/R/create_hystreet_request.R
@@ -41,7 +41,7 @@
   ## Let´S GETTED STARTED
   ##=======================================##
   
-  host <- "https://hystreet.com/api/locations"
+  host <- "https://api.hystreet.com/locations"
   header_type <- "application/vnd.hystreet.v1" 
   
   url <- httr::modify_url(host, path = c("api", "locations", hystreetId))


### PR DESCRIPTION
Dear Johannes,

thanks again for maintaining this great and very useful package. I created this PR because there are some important news for your package: hystreet.com is changing its base API URL. The new API URL now is: https://api.hystreet.com. I got word of it via e-mail as an active API user. The old URL will continue to function for a short period of time, but at the very least starting from 31-12-2022 will probably not be working anymore. 

You can find this to be in effect here: https://static.hystreet.com/#/operations/List%20Locations. As of yet, this is announced to be the only change. All parameter names and endpoint names should remain the same. I therefore exchanged the URL in the one function that I could find using it (create_hystreet_request.R). 

I also updated the DESCRIPTION file, updating the date (which was still invalid) and increased the version number (one could think about going up to 0.1.0 at some point). 

**In order for the package to continue to be helpful for researchers and other API users, this new code needs to go to CRAN.** If you need any help on a resubmission to CRAN, just hit me up so this can be up asap :-) 

All the best
Yannik

